### PR TITLE
fix: use HttpClient for NTLM callback to NAV endpoint

### DIFF
--- a/ServiceTrashInspectionPlugin/Handlers/EformCompletedHandler.cs
+++ b/ServiceTrashInspectionPlugin/Handlers/EformCompletedHandler.cs
@@ -21,8 +21,12 @@ SOFTWARE.
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.ServiceModel;
+using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microting.eForm.Dto;
 using Microting.eForm.Infrastructure;
@@ -226,61 +230,61 @@ public class eFormCompletedHandler : IHandleMessages<eFormCompleted>
         }
     }
 
+    // urn/namespace of the NAV MicrotingWS codeunit, matching the generated service reference.
+    private const string MicrotingWsNamespace = "urn:microsoft-dynamics-schemas/codeunit/MicrotingWS";
+
     private async Task CallUrlNtlmAuth(string callBackUrl, string callBackCredentialDomain,
         string callbackCredentialUserName, string callbackCredentialPassword, TrashInspection trashInspection,
         bool inspectionApproved)
     {
+        // WCF's ChannelFactory NTLM handshake fails on modern .NET against servers that offer only
+        // 'WWW-Authenticate: NTLM' (single scheme), which is exactly what this NAV endpoint returns.
+        // This is a documented, unresolved WCF-on-.NET-Core limitation (dotnet/wcf #4520, #4094, #5515).
+        // HttpClient's NTLM handshake is reliable here, so we issue the SOAP call directly.
+        XNamespace soapNs = "http://schemas.xmlsoap.org/soap/envelope/";
+        XNamespace svcNs = MicrotingWsNamespace;
 
-        ChannelFactory<MicrotingWS_Port> factory;
-        MicrotingWS_Port serviceProxy;
-        BasicHttpBinding basicHttpBindingntlm =
-            new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
-        basicHttpBindingntlm.Security.Transport.ClientCredentialType =
-            HttpClientCredentialType.Ntlm;
-        factory =
-            new ChannelFactory<MicrotingWS_Port>(basicHttpBindingntlm,
-                new EndpointAddress(
-                    new Uri(callBackUrl)));
+        XDocument envelope = new XDocument(
+            new XDeclaration("1.0", "utf-8", null),
+            new XElement(soapNs + "Envelope",
+                new XAttribute(XNamespace.Xmlns + "soap", soapNs.NamespaceName),
+                new XAttribute(XNamespace.Xmlns + "ns", svcNs.NamespaceName),
+                new XElement(soapNs + "Body",
+                    new XElement(svcNs + "WeighingFromMicroting2",
+                        new XElement(svcNs + "_WeighingNo", trashInspection.WeighingNumber),
+                        new XElement(svcNs + "_Approved", inspectionApproved)))));
 
-        if (callBackCredentialDomain != "...")
-        {
-            factory.Credentials.Windows.ClientCredential.Domain = callBackCredentialDomain;
-        }
+        NetworkCredential credential = callBackCredentialDomain != "..."
+            ? new NetworkCredential(callbackCredentialUserName, callbackCredentialPassword, callBackCredentialDomain)
+            : new NetworkCredential(callbackCredentialUserName, callbackCredentialPassword);
 
-        factory.Credentials.Windows.ClientCredential.UserName = callbackCredentialUserName;
-        factory.Credentials.Windows.ClientCredential.Password = callbackCredentialPassword;
-
-        serviceProxy = factory.CreateChannel();
-        ((ICommunicationObject)serviceProxy).Open();
+        using HttpClientHandler handler = new HttpClientHandler { Credentials = credential };
+        using HttpClient httpClient = new HttpClient(handler);
 
         try
         {
-            WeighingFromMicroting2 weighingFromMicroting2 =
-                new WeighingFromMicroting2(trashInspection.WeighingNumber, inspectionApproved);
-            Task<WeighingFromMicroting2_Result> result =
-                serviceProxy.WeighingFromMicroting2Async(weighingFromMicroting2);
+            using StringContent content = new StringContent(
+                envelope.Declaration + envelope.ToString(SaveOptions.DisableFormatting),
+                Encoding.UTF8, "text/xml");
+            content.Headers.Add("SOAPAction", $"\"{MicrotingWsNamespace}:WeighingFromMicroting2\"");
 
+            HttpResponseMessage response = await httpClient.PostAsync(callBackUrl, content);
+            string responseBody = await response.Content.ReadAsStringAsync();
+            response.EnsureSuccessStatusCode();
 
-            Console.WriteLine("[DBG] Result is " + result.Result.return_value);
-            trashInspection.SuccessMessageFromCallBack = result.Result.return_value;
+            string returnValue = XDocument.Parse(responseBody).Descendants()
+                .FirstOrDefault(x => x.Name.LocalName == "return_value")?.Value;
+
+            Console.WriteLine("[DBG] Result is " + returnValue);
+            trashInspection.SuccessMessageFromCallBack = returnValue;
             trashInspection.ResponseSendToCallBackUrl = true;
             await trashInspection.Update(_dbContext);
-
         }
         catch (Exception ex)
         {
             Console.WriteLine("[ERR] We got the following error: " + ex.Message);
             trashInspection.ErrorFromCallBack = ex.Message;
             await trashInspection.Update(_dbContext);
-        }
-        finally
-        {
-            // cleanup
-            factory.Close();
-            ((ICommunicationObject)serviceProxy).Close();
-            // *** ENSURE CLEANUP *** \\
-            //CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
-            //OperationContext.Current = prevOpContext; // Or set to null if you didn't capture the previous context
         }
     }
 }


### PR DESCRIPTION
## Problem

When the service posts a completed trash inspection to the NAV callback endpoint over NTLM, it fails with:

```
[ERR] We got the following error: One or more errors occurred.
(The HTTP request is unauthorized with client authentication scheme 'Ntlm'.
 The authentication header received from the server was 'NTLM'.)
```

## Root cause

Not a credential/config issue. WCF's `ChannelFactory` NTLM handshake fails on modern .NET (Core/5+/10) against servers that advertise only `WWW-Authenticate: NTLM` (single scheme) — exactly what this NAV endpoint returns. This is a documented, unresolved WCF-on-.NET-Core limitation (dotnet/wcf [#4520](https://github.com/dotnet/wcf/issues/4520), [#4094](https://github.com/dotnet/wcf/issues/4094), [#5515](https://github.com/dotnet/wcf/issues/5515)). The same credentials succeed via Postman / on .NET Framework 4.x.

## Fix

Replace the WCF `ChannelFactory` in `CallUrlNtlmAuth` with a direct `HttpClient` SOAP POST using `HttpClientHandler.Credentials = NetworkCredential(user, password, domain)`. `HttpClient`'s NTLM handshake is reliable on .NET Core.

- SOAP envelope, namespace, `SOAPAction`, and `return_value` parsing match the generated service reference exactly (`WeighingFromMicroting2` / `_WeighingNo` / `_Approved`).
- Preserves the existing `"..." ⇒ no domain` convention.
- `EnsureSuccessStatusCode()` routes faults/401s into the existing `catch`, so `ErrorFromCallBack` is still populated.
- The basic-auth path (`CallUrlBaiscAuth`) is unchanged.

## Verification

- ✅ Builds clean (`dotnet build`).
- ⚠️ Not verifiable against the live endpoint from CI — the real test is a completed inspection reaching the customer's NAV. Once confirmed working in production, a regression test will be added to lock in the SOAP envelope + parsing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)