### PR TITLE
chore: trim NTLM diagnostics + add NavSoap regression tests

### DIFF
--- a/ServiceTrashInspectionPlugin.Integration.Test/Helpers/NavSoapTests.cs
+++ b/ServiceTrashInspectionPlugin.Integration.Test/Helpers/NavSoapTests.cs
@@ -1,0 +1,94 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2007 - 2025 Microting A/S
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Linq;
+using System.Xml.Linq;
+using NUnit.Framework;
+using ServiceTrashInspectionPlugin.Infrastructure.Helpers;
+
+namespace ServiceTrashInspectionPlugin.Integration.Test.Helpers;
+
+/// <summary>
+/// Regression tests for the NAV MicrotingWS SOAP envelope construction and response parsing
+/// used by the WeighingFromMicroting2 callback (eFormCompletedHandler.CallUrlNtlmAuth).
+/// </summary>
+[TestFixture]
+public class NavSoapTests
+{
+    private const string Ns = "urn:microsoft-dynamics-schemas/codeunit/MicrotingWS";
+
+    [Test]
+    public void BuildEnvelope_StartsWithXmlDeclaration()
+    {
+        string soap = NavSoap.BuildWeighingFromMicroting2Envelope("V250790", true);
+
+        Assert.That(soap, Does.StartWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>"));
+    }
+
+    [Test]
+    [TestCase(true, "true")]
+    [TestCase(false, "false")]
+    public void BuildEnvelope_SerializesWeighingNoAndApproved(bool approved, string expectedApproved)
+    {
+        string soap = NavSoap.BuildWeighingFromMicroting2Envelope("V250790", approved);
+
+        XNamespace svc = Ns;
+        XElement operation = XDocument.Parse(soap).Descendants(svc + "WeighingFromMicroting2").Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(operation.Element(svc + "_WeighingNo")!.Value, Is.EqualTo("V250790"));
+            Assert.That(operation.Element(svc + "_Approved")!.Value, Is.EqualTo(expectedApproved));
+        });
+    }
+
+    [Test]
+    public void BuildEnvelope_EscapesSpecialCharactersInWeighingNo()
+    {
+        // Would produce invalid XML (and XDocument.Parse would throw) if the value were not escaped.
+        string soap = NavSoap.BuildWeighingFromMicroting2Envelope("A&B<C>", true);
+
+        XNamespace svc = Ns;
+        Assert.That(XDocument.Parse(soap).Descendants(svc + "_WeighingNo").Single().Value, Is.EqualTo("A&B<C>"));
+    }
+
+    [Test]
+    public void ParseReturnValue_ExtractsValueFromNavResponse()
+    {
+        // Response shape observed live from the NAV endpoint.
+        string response =
+            "<Soap:Envelope xmlns:Soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><Soap:Body>" +
+            "<WeighingFromMicroting2_Result xmlns=\"urn:microsoft-dynamics-schemas/codeunit/MicrotingWS\">" +
+            "<return_value>Vejenr. V250790 opdateret med Yes</return_value>" +
+            "</WeighingFromMicroting2_Result></Soap:Body></Soap:Envelope>";
+
+        Assert.That(NavSoap.ParseReturnValue(response), Is.EqualTo("Vejenr. V250790 opdateret med Yes"));
+    }
+
+    [Test]
+    public void ParseReturnValue_ReturnsNull_WhenAbsent()
+    {
+        string response =
+            "<Soap:Envelope xmlns:Soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+            "<Soap:Body><SomethingElse /></Soap:Body></Soap:Envelope>";
+
+        Assert.That(NavSoap.ParseReturnValue(response), Is.Null);
+    }
+}

--- a/ServiceTrashInspectionPlugin/Handlers/EformCompletedHandler.cs
+++ b/ServiceTrashInspectionPlugin/Handlers/EformCompletedHandler.cs
@@ -26,7 +26,6 @@ using System.Net.Http;
 using System.ServiceModel;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microting.eForm.Dto;
 using Microting.eForm.Infrastructure;
@@ -230,42 +229,20 @@ public class eFormCompletedHandler : IHandleMessages<eFormCompleted>
         }
     }
 
-    // urn/namespace of the NAV MicrotingWS codeunit, matching the generated service reference.
-    private const string MicrotingWsNamespace = "urn:microsoft-dynamics-schemas/codeunit/MicrotingWS";
-
     private async Task CallUrlNtlmAuth(string callBackUrl, string callBackCredentialDomain,
         string callbackCredentialUserName, string callbackCredentialPassword, TrashInspection trashInspection,
         bool inspectionApproved)
     {
         // WCF's ChannelFactory NTLM handshake fails on modern .NET against servers that offer only
-        // 'WWW-Authenticate: NTLM' (single scheme), which is exactly what this NAV endpoint returns.
-        // This is a documented, unresolved WCF-on-.NET-Core limitation (dotnet/wcf #4520, #4094, #5515).
-        // HttpClient's NTLM handshake is reliable here, so we issue the SOAP call directly.
-        XNamespace soapNs = "http://schemas.xmlsoap.org/soap/envelope/";
-        XNamespace svcNs = MicrotingWsNamespace;
+        // 'WWW-Authenticate: NTLM' (single scheme), which is exactly what this NAV endpoint returns
+        // (dotnet/wcf #4520, #4094, #5515), so we issue the SOAP call via HttpClient. NTLM on the
+        // Linux container additionally requires gss-ntlmssp + the OpenSSL legacy provider, enabled in
+        // Dockerfile-service, otherwise the handshake crypto is unavailable and the server returns 401.
+        string soapBody = NavSoap.BuildWeighingFromMicroting2Envelope(trashInspection.WeighingNumber, inspectionApproved);
 
-        XDocument envelope = new XDocument(
-            new XDeclaration("1.0", "utf-8", null),
-            new XElement(soapNs + "Envelope",
-                new XAttribute(XNamespace.Xmlns + "soap", soapNs.NamespaceName),
-                new XAttribute(XNamespace.Xmlns + "ns", svcNs.NamespaceName),
-                new XElement(soapNs + "Body",
-                    new XElement(svcNs + "WeighingFromMicroting2",
-                        new XElement(svcNs + "_WeighingNo", trashInspection.WeighingNumber),
-                        new XElement(svcNs + "_Approved", inspectionApproved)))));
-        string soapBody = envelope.Declaration + envelope.ToString(SaveOptions.DisableFormatting);
-
-        bool hasDomain = callBackCredentialDomain != "...";
-        NetworkCredential credential = hasDomain
+        NetworkCredential credential = callBackCredentialDomain != "..."
             ? new NetworkCredential(callbackCredentialUserName, callbackCredentialPassword, callBackCredentialDomain)
             : new NetworkCredential(callbackCredentialUserName, callbackCredentialPassword);
-
-        Console.WriteLine("[DBG][NTLM] ===== Preparing NTLM callback =====");
-        Console.WriteLine($"[DBG][NTLM] POST {callBackUrl}");
-        Console.WriteLine($"[DBG][NTLM] Credentials configured (domain {(hasDomain ? "set" : "not set")})");
-        Console.WriteLine($"[DBG][NTLM] SOAPAction=\"{MicrotingWsNamespace}:WeighingFromMicroting2\"");
-        Console.WriteLine("[DBG][NTLM] Request body:");
-        Console.WriteLine(soapBody);
 
         using HttpClientHandler handler = new HttpClientHandler { Credentials = credential };
         using HttpClient httpClient = new HttpClient(handler);
@@ -273,23 +250,10 @@ public class eFormCompletedHandler : IHandleMessages<eFormCompleted>
         try
         {
             using StringContent content = new StringContent(soapBody, Encoding.UTF8, "text/xml");
-            content.Headers.Add("SOAPAction", $"\"{MicrotingWsNamespace}:WeighingFromMicroting2\"");
+            content.Headers.Add("SOAPAction", $"\"{NavSoap.WeighingFromMicroting2Action}\"");
 
             HttpResponseMessage response = await httpClient.PostAsync(callBackUrl, content);
             string responseBody = await response.Content.ReadAsStringAsync();
-
-            Console.WriteLine($"[DBG][NTLM] Response status: {(int)response.StatusCode} {response.ReasonPhrase}");
-            Console.WriteLine("[DBG][NTLM] Response headers:");
-            foreach (KeyValuePair<string, IEnumerable<string>> header in response.Headers)
-            {
-                Console.WriteLine($"[DBG][NTLM]   {header.Key}: {string.Join(", ", header.Value)}");
-            }
-            foreach (KeyValuePair<string, IEnumerable<string>> header in response.Content.Headers)
-            {
-                Console.WriteLine($"[DBG][NTLM]   {header.Key}: {string.Join(", ", header.Value)}");
-            }
-            Console.WriteLine("[DBG][NTLM] Response body:");
-            Console.WriteLine(responseBody);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -304,8 +268,7 @@ public class eFormCompletedHandler : IHandleMessages<eFormCompleted>
                 return;
             }
 
-            string returnValue = XDocument.Parse(responseBody).Descendants()
-                .FirstOrDefault(x => x.Name.LocalName == "return_value")?.Value;
+            string returnValue = NavSoap.ParseReturnValue(responseBody);
 
             Console.WriteLine("[DBG][NTLM] Result is " + returnValue);
             trashInspection.SuccessMessageFromCallBack = returnValue;
@@ -314,11 +277,7 @@ public class eFormCompletedHandler : IHandleMessages<eFormCompleted>
         }
         catch (Exception ex)
         {
-            Console.WriteLine("[ERR][NTLM] Exception during callback: " + ex);
-            for (Exception inner = ex.InnerException; inner != null; inner = inner.InnerException)
-            {
-                Console.WriteLine("[ERR][NTLM] Inner exception: " + inner);
-            }
+            Console.WriteLine("[ERR][NTLM] Exception during callback: " + ex.Message);
             trashInspection.ErrorFromCallBack = ex.Message;
             await trashInspection.Update(_dbContext);
         }

--- a/ServiceTrashInspectionPlugin/Infrastructure/Helpers/NavSoap.cs
+++ b/ServiceTrashInspectionPlugin/Infrastructure/Helpers/NavSoap.cs
@@ -1,0 +1,68 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2007 - 2025 Microting A/S
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Linq;
+using System.Xml.Linq;
+
+namespace ServiceTrashInspectionPlugin.Infrastructure.Helpers;
+
+/// <summary>
+/// Builds and parses the SOAP messages for the NAV MicrotingWS codeunit, matching the
+/// generated service reference (see Connected Services/ServiceReference1).
+/// </summary>
+public static class NavSoap
+{
+    /// <summary>urn/namespace of the NAV MicrotingWS codeunit.</summary>
+    public const string MicrotingWsNamespace = "urn:microsoft-dynamics-schemas/codeunit/MicrotingWS";
+
+    /// <summary>SOAPAction for the WeighingFromMicroting2 operation.</summary>
+    public const string WeighingFromMicroting2Action = MicrotingWsNamespace + ":WeighingFromMicroting2";
+
+    /// <summary>
+    /// Builds the SOAP 1.1 request body for the WeighingFromMicroting2 operation.
+    /// </summary>
+    public static string BuildWeighingFromMicroting2Envelope(string weighingNo, bool approved)
+    {
+        XNamespace soapNs = "http://schemas.xmlsoap.org/soap/envelope/";
+        XNamespace svcNs = MicrotingWsNamespace;
+
+        XDocument envelope = new XDocument(
+            new XDeclaration("1.0", "utf-8", null),
+            new XElement(soapNs + "Envelope",
+                new XAttribute(XNamespace.Xmlns + "soap", soapNs.NamespaceName),
+                new XAttribute(XNamespace.Xmlns + "ns", svcNs.NamespaceName),
+                new XElement(soapNs + "Body",
+                    new XElement(svcNs + "WeighingFromMicroting2",
+                        new XElement(svcNs + "_WeighingNo", weighingNo),
+                        new XElement(svcNs + "_Approved", approved)))));
+
+        return envelope.Declaration + envelope.ToString(SaveOptions.DisableFormatting);
+    }
+
+    /// <summary>
+    /// Extracts the &lt;return_value&gt; text from a WeighingFromMicroting2 SOAP response,
+    /// or null when absent.
+    /// </summary>
+    public static string ParseReturnValue(string responseBody)
+    {
+        return XDocument.Parse(responseBody).Descendants()
+            .FirstOrDefault(x => x.Name.LocalName == "return_value")?.Value;
+    }
+}


### PR DESCRIPTION
## Why

The v10.0.13 fix (`gss-ntlmssp` + OpenSSL legacy provider) is **confirmed working in production** — a real inspection callback returned `200 OK` and NAV `return_value` *"Vejenr. V250790 opdateret med Yes"*. So the temporary verbose NTLM wire-dump can go, and the SOAP path gets proper test coverage.

## Changes

- **Trim diagnostics** in `CallUrlNtlmAuth`: remove the per-request/response/header/body `[DBG][NTLM]` dump. Keep a concise success log (`Result is …`) and the detailed **error** record on non-2xx (status + `WWW-Authenticate` + body) so future failures stay diagnosable.
- **Extract `NavSoap`** helper: `BuildWeighingFromMicroting2Envelope` + `ParseReturnValue` (previously inline), so the SOAP logic is unit-testable.
- **Regression tests** (`NavSoapTests`): envelope structure + namespace, `_Approved` bool serialization (`true`/`false`), XML escaping of the weighing number, parsing the **live** NAV response shape, and null-on-absent.

The pre-existing plaintext credential logs in the `#region get settings` block are intentionally left as-is (per request).

## Verification

- `dotnet test` → **24 passed, 0 failed** (6 new `NavSoap` cases).
- No behavioural change to the callback; logging-only + refactor + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)